### PR TITLE
Initial dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM jjanzic/docker-python3-opencv:latest
+
+RUN git clone https://github.com/lessthanoptimal/SpeedTestCV.git
+WORKDIR /SpeedTestCV/opencv
+
+# See https://github.com/lessthanoptimal/SpeedTestCV/tree/master/opencv
+RUN python3 -m venv venv && \
+		. venv/bin/activate && \
+		pip3 install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # docker-eval
 Source code for an experiment evaluating to what extent docker can make experimental results repeatable, regardless of the platform and hardware.
+
+## Getting Started
+
+1. Install Docker [here](https://docs.docker.com/get-docker/).
+2. Build the docker image with `docker build --tag imagebench:1.0 .`.
+3. Run the docker container with
+   `docker run -it --name ib imagebench:1.0 python3	benchmark.py`.
+   This will run the benchmarks in the container and let you interact with
+   the prompt after it finishes.
+4. Stop the docker container `docker rm --force ib`.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Source code for an experiment evaluating to what extent docker can make experime
 1. Install Docker [here](https://docs.docker.com/get-docker/).
 2. Build the docker image with `docker build --tag imagebench:1.0 .`.
 3. Run the docker container with
-   `docker run -it --name ib imagebench:1.0 python3	benchmark.py`.
+   `docker run -it --name ib imagebench:1.0 python3 benchmark.py`.
    This will run the benchmarks in the container and let you interact with
    the prompt after it finishes.
 4. Stop the docker container `docker rm --force ib`.


### PR DESCRIPTION
This is a starting point, just so we can all test to see if we can get things running smoothly on all platforms.

- Created an initial dockerfile that has opencv in it. We may want to base our image off `python:3.8` instead of what I did and then manually install OpenCV (along with whatever other toolkits we want), but this was quick and dirty to see if I could get the benchmarks @Cheryl-Lao found.
- Added a Readme section on how to run the docker container