### PR TITLE
Added a run-all script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 # Benchmark output folders
-*/output/*
+**/output/*
 
 # Vim swap files
 *.swp
 
-#Python temp folders
-*/benchmarks/__pycache__/*
+# Python temp folders
+**/benchmarks/__pycache__
+
+# The virtual python environment
+**/venv

--- a/run-all.sh
+++ b/run-all.sh
@@ -57,6 +57,7 @@ for n in {0..9}; do
 	echo '=================================='
 	
 	# Native trial
+	echo "Performing trial $n---native"
 	$SOURCE benchmarks/venv/bin/activate
 	cd benchmarks && python3 benchmark.py && cd ..
 	deactivate
@@ -65,6 +66,7 @@ for n in {0..9}; do
 	mv output/results.csv "$OUT/native-$n.csv"
 
 	# Docker trial
+	echo "Performing trial $n---docker"
 	docker run -it --rm \
         --mount type=bind,source="$(pwd)/benchmarks",target=/benchmarks \
         --mount type=bind,source="$(pwd)/output",target=/output \

--- a/run-all.sh
+++ b/run-all.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# run-all.sh runs the entire benchmark suite twenty times.
+# First, it runs it natively once. Then, it starts up the docker
+# container and runs it in docker once. After stopping the docker
+# container, this whole process repeats 9 times.
+
+# Get the source command we will need to use, based on OS
+# (on Linux, rather than doing "source SOME_FILE", you do
+# ". SOME_FILE").
+case "$(uname -s)" in
+    Darwin*)    SOURCE='source';;
+    *)          SOURCE='.'
+esac
+
+# Make sure output directory exists
+if ! [ -d 'output' ]; then
+	mkdir output
+fi
+
+# Make the experiment's output subdirectory
+OUT="output/$(date +'%m-%d-%Y_%H-%M-%S')"
+mkdir $OUT
+
+#===========================================================
+# Ensure docker and native is set up and ready to go
+#===========================================================
+
+# Step 1: build the image if not already built
+#if [ $(docker images | grep 'opencv-py' | wc -l) -eq 0 ]; then
+#	echo 'Building docker image opencv-py:1.0'
+#	docker build --tag opencv-py:1.0 .
+#fi
+
+# Step 2: check if the venv is set up.
+if ! $SOURCE benchmarks/venv/bin/activate; then
+	echo 'CRITICAL ERROR: Failed to activate venv for native python setup'
+	exit 1
+fi
+
+# Step 3: check if the packages are available inside of venv
+if ! python3 -c 'import cv2 ; import numpy ; import psutil'; then
+	echo 'CRITICAL ERROR: Failed to import cv2, numpy, or psutil in the native venv'
+	exit 1
+fi
+
+# Shut down the venv for now
+deactivate
+
+#===========================================================
+# Run 10 trials
+#===========================================================
+
+for n in {0..9}; do
+	echo '=================================='
+	echo "Performing trial $n"
+	echo '=================================='
+	
+	# Native trial
+	$SOURCE benchmarks/venv/bin/activate
+	cd benchmarks && python3 benchmark.py && cd ..
+	deactivate
+
+	# Get the most recent item, move it
+	mv output/results.csv "$OUT/native-$n.csv"
+
+	# Docker trial
+	docker run -it --rm \
+        --mount type=bind,source="$(pwd)/benchmarks",target=/benchmarks \
+        --mount type=bind,source="$(pwd)/output",target=/output \
+        opencv-py:1.0 python3 benchmark.py
+	
+	# Get the most recent item, move it
+	mv output/results.csv "$OUT/docker-$n.csv"
+done
+
+echo "Experiment complete! See the results in the folder $OUT"

--- a/run-all.sh
+++ b/run-all.sh
@@ -8,10 +8,8 @@
 # Get the source command we will need to use, based on OS
 # (on Linux, rather than doing "source SOME_FILE", you do
 # ". SOME_FILE").
-case "$(uname -s)" in
-    Darwin*)    SOURCE='source';;
-    *)          SOURCE='.'
-esac
+SOURCE='source'
+ENV_ACTIVATE='venv/bin/activate'
 
 # Make sure output directory exists
 if ! [ -d 'output' ]; then
@@ -33,7 +31,7 @@ mkdir $OUT
 #fi
 
 # Step 2: check if the venv is set up.
-if ! $SOURCE benchmarks/venv/bin/activate; then
+if ! $SOURCE $ENV_ACTIVATE; then
 	echo 'CRITICAL ERROR: Failed to activate venv for native python setup'
 	exit 1
 fi
@@ -58,7 +56,7 @@ for n in {0..9}; do
 	
 	# Native trial
 	echo "Performing trial $n---native"
-	$SOURCE benchmarks/venv/bin/activate
+	$SOURCE $ENV_ACTIVATE
 	cd benchmarks && python3 benchmark.py && cd ..
 	deactivate
 


### PR DESCRIPTION
This adds a bash script to run the docker and native trials interleaved. It should work on mac and linux.

Note that it assumes you have correctly set up a `venv` for your python setup on your native installation; it will throw an error if you have not done so already. You will have to make a symlink to the opencv `cv.so` file within the venv's `venv/lib/python3.6/site-packages/` folder to make it work. For my (somewhat unique) installation, I made the symlink to `/usr/local/lib/python3.6/site-packages/cv2/python-3.6/cv2.opencv4.1.1.so`.